### PR TITLE
Fixes lint warnings and adds lint checking to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,22 @@ jobs:
           command: dep ensure
 
       - run:
+          name: Run go vet to check for likely mistakes in packages
+          command: go vet
+
+      - run:
+          name: Install goLint
+          command: |
+            go get -u golang.org/x/lint/golint
+            go get -u github.com/GeertJohan/fgt
+
+      # Using fgt to run golint causes the build to fail if any lint is found. 
+      # Otherwise, golint always returns a 0 result.
+      - run:
+          name: Lint checks
+          command: fgt golint
+
+      - run:
           name: Run go test
           command: go test
 

--- a/broker.go
+++ b/broker.go
@@ -132,7 +132,7 @@ func (b awsAccountBroker) LastOperation(ctx context.Context, instanceID, operati
 	return op, err
 }
 
-func NewAWSAccountBroker(baseEmail string, logger lager.Logger, db *gorm.DB) (awsAccountBroker, error) {
+func newAWSAccountBroker(baseEmail string, logger lager.Logger, db *gorm.DB) (awsAccountBroker, error) {
 	mgr, err := newAccountManager()
 	return awsAccountBroker{mgr, baseEmail, logger, db}, err
 }

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 	}
 	defer db.Close()
 
-	broker, err := NewAWSAccountBroker(baseEmail, logger, db)
+	broker, err := newAWSAccountBroker(baseEmail, logger, db)
 	if err != nil {
 		logger.Fatal("Problem starting broker", err)
 	}


### PR DESCRIPTION
- Fixes lint warnings related to making NewAWSAccountBroker function public by making it private (i.e. starts with lowercase n)
- Adds lint checks to CircleCI config (Note: I've configured CircleCI to fail if lint is found, which may be a bit harsh)
- Closes #10 